### PR TITLE
fix: dedupe logic now applied when only one script passed

### DIFF
--- a/ts/gulpfile.ts
+++ b/ts/gulpfile.ts
@@ -21,12 +21,7 @@ const project: buildTools.Project = {
   buildDir: "build",
   distDir: "dist",
   srcDir: "src",
-  typescript: {
-    compilerOptions: {
-      allowSyntheticDefaultImports: true,
-      esModuleInterop: true,
-    },
-  },
+  typescript: {}
 };
 
 const lib: LibTarget = {

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@c88/v8-coverage",
-  "version": "0.1.0",
+  "name": "@bcoe/v8-coverage",
+  "version": "0.2.2",
   "description": "Helper functions for V8 coverage files.",
   "author": "Charles Samborski <demurgos@demurgos.net> (https://demurgos.net)",
   "license": "MIT",

--- a/ts/package.json
+++ b/ts/package.json
@@ -30,8 +30,8 @@
     "gulp-cli": "^2.0.1",
     "minimist": "^1.2.0",
     "pre-commit": "^1.2.2",
-    "ts-node": "^7.0.0",
-    "turbo-gulp": "^0.17.1"
+    "ts-node": "^8.3.0",
+    "turbo-gulp": "^0.20.1"
   },
   "nyc": {
     "include": [

--- a/ts/package.json
+++ b/ts/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://demurgos.github.io/v8-coverage",
   "scripts": {
-    "prepare": "gulp all:tsconfig.json && gulp :tslint.json && gulp dist",
+    "prepare": "gulp all:tsconfig.json && gulp dist",
     "pretest": "gulp lib:build",
     "test": "gulp test",
     "prepublishOnly": "npm test",

--- a/ts/src/lib/merge.ts
+++ b/ts/src/lib/merge.ts
@@ -23,10 +23,6 @@ import { FunctionCov, ProcessCov, Range, RangeCov, ScriptCov } from "./types";
 export function mergeProcessCovs(processCovs: ReadonlyArray<ProcessCov>): ProcessCov {
   if (processCovs.length === 0) {
     return {result: []};
-  } else if (processCovs.length === 1) {
-    const merged: ProcessCov = processCovs[0];
-    deepNormalizeProcessCov(merged);
-    return merged;
   }
 
   const urlToScripts: Map<string, ScriptCov[]> = new Map();

--- a/ts/src/lib/merge.ts
+++ b/ts/src/lib/merge.ts
@@ -1,5 +1,4 @@
 import {
-  deepNormalizeProcessCov,
   deepNormalizeScriptCov,
   normalizeFunctionCov,
   normalizeProcessCov,


### PR DESCRIPTION
Libraries like `proxyquire` can cause situations in which scripts are loaded multiple times within the same coverage output file. This PR removes the optimization step of skipping merging when only one file exists.