### PR TITLE
fix: correct repo link in package.json

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -7,9 +7,8 @@
   "main": "./src/lib/index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/demurgos/v8-coverage.git"
+    "url": "git://github.com/bcoe/v8-coverage.git"
   },
-  "homepage": "https://demurgos.github.io/v8-coverage",
   "scripts": {
     "test": "c8 mocha ./src/test/*.js",
     "posttest": "prettier --check ./src/lib/*.js",


### PR DESCRIPTION
The links in this automated PR points wrong: https://github.com/jestjs/jest/pull/15451